### PR TITLE
fix: Fixed BaseTimeEntity class

### DIFF
--- a/src/main/java/com/f_lab/la_planete/config/JpaConfig.java
+++ b/src/main/java/com/f_lab/la_planete/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.f_lab.la_planete.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/com/f_lab/la_planete/domain/Food.java
+++ b/src/main/java/com/f_lab/la_planete/domain/Food.java
@@ -1,0 +1,48 @@
+package com.f_lab.la_planete.domain;
+
+import com.f_lab.la_planete.domain.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@Setter(PRIVATE)
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "foods")
+public class Food extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+
+  private BigDecimal price;
+
+  private int quantity;
+
+  @ManyToOne(fetch = LAZY)
+  @JoinColumn(name = "store_id")
+  private Store store;
+
+  public static Food of(BigDecimal price, int quantity) {
+    Food food = new Food();
+    food.setPrice(price);
+    food.setQuantity(quantity);
+    return food;
+  }
+
+  public void minusQuantity(int deductions) {
+    if (quantity - deductions < 0)
+      throw new IllegalStateException("수량이 부족합니다. 따라서 구매가 진행될 수 없습니다.");
+
+    quantity -= deductions;
+  }
+}

--- a/src/main/java/com/f_lab/la_planete/domain/Order.java
+++ b/src/main/java/com/f_lab/la_planete/domain/Order.java
@@ -1,0 +1,28 @@
+package com.f_lab.la_planete.domain;
+
+import com.f_lab.la_planete.domain.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "orders")
+public class Order extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+
+  @Enumerated(EnumType.STRING)
+  private OrderStatus status;
+
+  @OneToOne(fetch = LAZY)
+  @JoinColumn(name = "payment_id")
+  private Payment payment;
+}

--- a/src/main/java/com/f_lab/la_planete/domain/OrderStatus.java
+++ b/src/main/java/com/f_lab/la_planete/domain/OrderStatus.java
@@ -1,0 +1,21 @@
+package com.f_lab.la_planete.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum OrderStatus {
+
+  READY("주문을 생성하면 가지게 되는 초기 상태입니다."),
+  IN_PROGRESS("주문이 진행되고 있는 상태입니다."),
+  DONE("주문이 완료된 상태입니다."),
+  MEMBER_CANCELED("승인된 결제가 사용자에 의해서 취소된 상태입니다."),
+  STORE_CANCELED("승인된 결제가 가게에 의해서 취소된 상태입니다."),
+  EXPIRED("주문의 유효 시간 5분이 지나 거래가 취소된 상태입니다."),
+  ;
+
+  private final String description;
+
+  private OrderStatus(String description) {
+    this.description = description;
+  }
+}

--- a/src/main/java/com/f_lab/la_planete/domain/Payment.java
+++ b/src/main/java/com/f_lab/la_planete/domain/Payment.java
@@ -1,0 +1,30 @@
+package com.f_lab.la_planete.domain;
+
+import com.f_lab.la_planete.domain.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "payments")
+public class Payment extends BaseEntity {
+
+  @Id @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+
+  private BigDecimal amount;
+
+  @Enumerated(EnumType.STRING)
+  private PaymentStatus status;
+
+  @OneToOne(mappedBy = "payment", fetch = LAZY)
+  private Order order;
+}

--- a/src/main/java/com/f_lab/la_planete/domain/PaymentStatus.java
+++ b/src/main/java/com/f_lab/la_planete/domain/PaymentStatus.java
@@ -1,0 +1,21 @@
+package com.f_lab.la_planete.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum PaymentStatus {
+
+  READY("결제를 생성하면 가지게 되는 초기 상태입니다. 인증 전까지는 READY 상태를 유지합니다."),
+  IN_PROGRESS("결제수단 정보와 해당 결제수단의 소유자가 맞는지 인증을 마친 상태입니다. 결제 승인 API를 호출하면 결제가 완료됩니다."),
+  DONE("인증된 결제수단으로 요청한 결제가 승인된 상태입니다."),
+  CANCELED("승인된 결제가 취소된 상태입니다."),
+  ABORTED("결제 승인이 실패한 상태입니다."),
+  EXPIRED("결제 유효 시간 5분이 지나 거래가 취소된 상태입니다."),
+  ;
+
+  private final String description;
+
+  private PaymentStatus(String description) {
+    this.description = description;
+  }
+}

--- a/src/main/java/com/f_lab/la_planete/domain/Store.java
+++ b/src/main/java/com/f_lab/la_planete/domain/Store.java
@@ -1,0 +1,28 @@
+package com.f_lab.la_planete.domain;
+
+import com.f_lab.la_planete.domain.base.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "stores")
+public class Store extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+
+  private String name;
+
+  @OneToMany(mappedBy = "store")
+  private List<Food> foods = new ArrayList<>();
+}

--- a/src/main/java/com/f_lab/la_planete/domain/base/BaseEntity.java
+++ b/src/main/java/com/f_lab/la_planete/domain/base/BaseEntity.java
@@ -1,0 +1,8 @@
+package com.f_lab.la_planete.domain.base;
+
+
+
+public abstract class BaseEntity extends BaseTimeEntity {
+
+  // TODO @CreatedBy & @LastModifiedBy AuditorAware 및 Spring Security 활용하여 구현해놓기
+}

--- a/src/main/java/com/f_lab/la_planete/domain/base/BaseTimeEntity.java
+++ b/src/main/java/com/f_lab/la_planete/domain/base/BaseTimeEntity.java
@@ -1,0 +1,17 @@
+package com.f_lab.la_planete.domain.base;
+
+import jakarta.persistence.EntityListeners;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+  @CreatedDate
+  private LocalDateTime createdAt;
+  @LastModifiedDate
+  private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/f_lab/la_planete/domain/base/BaseTimeEntity.java
+++ b/src/main/java/com/f_lab/la_planete/domain/base/BaseTimeEntity.java
@@ -1,16 +1,20 @@
 package com.f_lab.la_planete.domain.base;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+@MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseTimeEntity {
 
   @CreatedDate
+  @Column(updatable = false)
   private LocalDateTime createdAt;
   @LastModifiedDate
   private LocalDateTime modifiedAt;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 spring.application.name=la-planete
+spring.profiles.active=dev
+spring.jpa.hibernate.ddl-auto=create-drop
+
+logging.level.sql=trace

--- a/src/test/java/com/f_lab/la_planete/domain/FoodTest.java
+++ b/src/test/java/com/f_lab/la_planete/domain/FoodTest.java
@@ -1,0 +1,36 @@
+package com.f_lab.la_planete.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FoodTest {
+
+  @Test
+  @DisplayName("음식 수량을 줄였을 때 성공")
+  void test_minus_food_quantity_success() {
+    // given
+    Food food = Food.of(BigDecimal.valueOf(1000), 10);
+
+    // when
+    food.minusQuantity(5);
+
+    // then
+    assertThat(food.getQuantity()).isEqualTo(5);
+  }
+
+  @Test
+  @DisplayName("음식 수량을 줄였을 때 수량보다 많아서 실패할 때 예외 던짐")
+  void test_minus_food_quantity_fail() {
+    // given
+    Food food = Food.of(BigDecimal.valueOf(1000), 10);
+
+    // then
+    assertThatThrownBy(() -> food.minusQuantity(11))
+        .isInstanceOf(IllegalStateException.class);
+  }
+}


### PR DESCRIPTION
테이블에 BaseTimeEntity의 필드들이 반영되지 않는 것을 확인 한 후 버그를 수정하였습니다. 

@MappedSuperClass 어노테이션을 추가함으로써 필드가 테이블 생성시에 반영되도록 하였고 
@Column(updatable=false) 어노테이션을 createdAt 필드에 추가하여 변경 수정 이 안된다는 것을 명시적으로 적어두었습니다. 

그 후 아래의 로그를 참조한 것과 같이 정상적으로 테이블 생성이 작동하는 것을 확인하였습니다. 

create table foods (price numeric(38,2), quantity integer not null, created_at timestamp(6), id bigint generated by default as identity, modified_at timestamp(6), store_id bigint, primary key (id))