### PR TITLE
feat: Added OpenAPIConfig

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// swagger 패키지
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/f_lab/la_planete/config/OpenApiConfig.java
+++ b/src/main/java/com/f_lab/la_planete/config/OpenApiConfig.java
@@ -1,0 +1,31 @@
+package com.f_lab.la_planete.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+  @Bean
+  public OpenAPI openAPI() {
+    return new OpenAPI()
+        .info(apiInfo());
+  }
+
+  private Info apiInfo() {
+    return new Info()
+        .title("La-Planète API")
+        .description("API for La-Planète, a food saving app")
+        .version("1.0.0")
+        .contact(creatorContact());
+  }
+
+  private Contact creatorContact() {
+    return new Contact()
+        .name("Gunho Ryu")
+        .email("paulyu1998@gmail.com");
+  }
+}


### PR DESCRIPTION
- **Open API Spec** 에 대해서 조사를 진행 ([여기](https://velog.io/@kakao513/Open-API-Spec)) 
- 그 후 프로젝트에 **Open API Spec** 자동화를 **Spring Doc** 을 사용하여  구현

**Spring Doc** 과 **Spring Fox**를 고려해 보았고

- **Spring Fox**가 **Spring Boot 3.xx** 버전 부터는 호환이 **Spring Doc**에 비해서 좋지 않다는 의견 [여기](https://www.baeldung.com/swagger-2-documentation-for-spring-rest-api) 및
- **Spring Fox**가 유지보수가 잘 이루어지고 있다는 것을 고려하여 [여기](https://stackoverflow.com/questions/72479827/are-there-any-advantages-of-using-migrating-to-springdoc-openapi-from-springfox)

**Spring Doc**으로 **Open API Spec** 자동화를 구현하기로 결정하였습니다. 

결과 

<img width="1318" alt="스크린샷 2024-12-21 오후 2 02 23" src="https://github.com/user-attachments/assets/ef68bede-aba0-43e2-9c7d-16b59ce4e1fb" />