### PR TITLE
fix: Fixed BaseTimeEntity class

### DIFF
--- a/src/main/java/com/f_lab/la_planete/domain/base/BaseTimeEntity.java
+++ b/src/main/java/com/f_lab/la_planete/domain/base/BaseTimeEntity.java
@@ -1,16 +1,20 @@
 package com.f_lab.la_planete.domain.base;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+@MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseTimeEntity {
 
   @CreatedDate
+  @Column(updatable = false)
   private LocalDateTime createdAt;
   @LastModifiedDate
   private LocalDateTime modifiedAt;


### PR DESCRIPTION
테이블에 BaseTimeEntity의 필드들이 반영되지 않는 것을 확인 한 후 버그를 수정하였습니다. 

@MappedSuperClass 어노테이션을 추가함으로써 필드가 테이블 생성시에 반영되도록 하였고 
@Column(updatable=false) 어노테이션을 createdAt 필드에 추가하여 변경 수정 이 안된다는 것을 명시적으로 적어두었습니다. 

그 후 아래의 로그를 참조한 것과 같이 정상적으로 테이블 생성이 작동하는 것을 확인하였습니다. 

create table foods (price numeric(38,2), quantity integer not null, created_at timestamp(6), id bigint generated by default as identity, modified_at timestamp(6), store_id bigint, primary key (id))