### PR TITLE
feat: Added basic order mvc

### DIFF
--- a/src/main/java/com/f_lab/la_planete/controller/OrderController.java
+++ b/src/main/java/com/f_lab/la_planete/controller/OrderController.java
@@ -1,0 +1,28 @@
+package com.f_lab.la_planete.controller;
+
+import com.f_lab.la_planete.dto.request.OrderCreateRequestDTO;
+import com.f_lab.la_planete.dto.response.OrderCreateResponseDTO;
+import com.f_lab.la_planete.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/orders")
+public class OrderController {
+
+  private final OrderService orderService;
+
+  @PostMapping("/foods")
+  public ResponseEntity<OrderCreateResponseDTO> createFoodOrder(
+      @RequestBody OrderCreateRequestDTO orderCreateRequestDTO) {
+
+    return ResponseEntity
+        .status(HttpStatus.CREATED)
+        .body(orderService.createFoodOrder(orderCreateRequestDTO));
+  }
+}

--- a/src/main/java/com/f_lab/la_planete/dto/request/OrderCreateRequestDTO.java
+++ b/src/main/java/com/f_lab/la_planete/dto/request/OrderCreateRequestDTO.java
@@ -1,0 +1,26 @@
+package com.f_lab.la_planete.dto.request;
+
+import com.f_lab.la_planete.domain.Food;
+import com.f_lab.la_planete.domain.Order;
+import com.f_lab.la_planete.domain.OrderStatus;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+public class OrderCreateRequestDTO {
+
+  @JsonProperty("food_id")
+  private Long foodId;
+  private BigDecimal price;
+  private int quantity;
+
+  public Order toEntity(Food food) {
+    return Order.builder()
+        .status(OrderStatus.READY)
+        .food(food)
+        .quantity(quantity)
+        .build();
+  }
+}

--- a/src/main/java/com/f_lab/la_planete/dto/response/OrderCreateResponseDTO.java
+++ b/src/main/java/com/f_lab/la_planete/dto/response/OrderCreateResponseDTO.java
@@ -1,0 +1,10 @@
+package com.f_lab.la_planete.dto.response;
+
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+public class OrderCreateResponseDTO {
+
+  private String message;
+}

--- a/src/main/java/com/f_lab/la_planete/repository/FoodRepository.java
+++ b/src/main/java/com/f_lab/la_planete/repository/FoodRepository.java
@@ -1,8 +1,21 @@
 package com.f_lab.la_planete.repository;
 
 import com.f_lab.la_planete.domain.Food;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
-
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.repository.query.Param;
 
 public interface FoodRepository extends JpaRepository<Food, Long> {
+
+  String FIVE_SECONDS = "5000";
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("SELECT f FROM Food f WHERE f.id = :id")
+  @QueryHints({ @QueryHint(name = "jakarta.persistence.lock.timeout", value = FIVE_SECONDS) })
+  Food findFoodByFoodIdWithPessimisticLock(@Param("id") Long id);
 }
+

--- a/src/main/java/com/f_lab/la_planete/repository/OrderRepository.java
+++ b/src/main/java/com/f_lab/la_planete/repository/OrderRepository.java
@@ -1,0 +1,8 @@
+package com.f_lab.la_planete.repository;
+
+
+import com.f_lab.la_planete.domain.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/src/main/java/com/f_lab/la_planete/service/OrderService.java
+++ b/src/main/java/com/f_lab/la_planete/service/OrderService.java
@@ -1,0 +1,69 @@
+package com.f_lab.la_planete.service;
+
+import com.f_lab.la_planete.domain.Food;
+import com.f_lab.la_planete.domain.Order;
+import com.f_lab.la_planete.domain.Payment;
+import com.f_lab.la_planete.dto.request.OrderCreateRequestDTO;
+import com.f_lab.la_planete.dto.response.OrderCreateResponseDTO;
+import com.f_lab.la_planete.repository.FoodRepository;
+import com.f_lab.la_planete.repository.OrderRepository;
+import com.f_lab.la_planete.repository.PaymentRepository;
+import jakarta.persistence.LockTimeoutException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.PessimisticLockException;
+import org.springframework.dao.PessimisticLockingFailureException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class OrderService {
+
+  private final OrderRepository orderRepository;
+  private final FoodRepository foodRepository;
+  private final PaymentRepository paymentRepository;
+
+  @Transactional(rollbackFor = IllegalStateException.class)
+  public OrderCreateResponseDTO createFoodOrder(OrderCreateRequestDTO request) {
+
+    // 음식을 조회 후 요청한 수 만큼 빼기
+    Food food = findFoodWithLock(request.getFoodId());
+    food.minusQuantity(request.getQuantity());
+    foodRepository.save(food);
+
+    // 주문 생성 후 총 금액 계산
+    Order order = request.toEntity(food);
+    BigDecimal totalCost = order.calculateTotalCost();
+    order.updateTotalCost(totalCost);
+
+    // 결제 생성
+    Payment payment = Payment.of(totalCost, order);
+
+    orderRepository.save(order);
+    paymentRepository.save(payment);
+
+    return new OrderCreateResponseDTO("CREATED");
+  }
+
+  private Food findFoodWithLock(Long foodId) {
+    try {
+      Food food = foodRepository.findFoodByFoodIdWithPessimisticLock(foodId);
+      Thread.sleep(5000);
+      return food;
+    } catch(PessimisticLockException | PessimisticLockingFailureException e) {
+      log.warn("Pessimistic lock failure on food ID: {}", foodId, e);
+
+      // Decide whether to retry, fallback, or fail
+      throw new IllegalStateException("The food item is currently locked. Please try again later.");
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}
+

--- a/src/main/java/com/f_lab/la_planete/service/OrderService.java
+++ b/src/main/java/com/f_lab/la_planete/service/OrderService.java
@@ -29,7 +29,7 @@ public class OrderService {
   private final FoodRepository foodRepository;
   private final PaymentRepository paymentRepository;
 
-  @Transactional(rollbackFor = IllegalStateException.class)
+  @Transactional
   public OrderCreateResponseDTO createFoodOrder(OrderCreateRequestDTO request) {
 
     // 음식을 조회 후 요청한 수 만큼 빼기
@@ -53,16 +53,10 @@ public class OrderService {
 
   private Food findFoodWithLock(Long foodId) {
     try {
-      Food food = foodRepository.findFoodByFoodIdWithPessimisticLock(foodId);
-      Thread.sleep(5000);
-      return food;
+     return  foodRepository.findFoodByFoodIdWithPessimisticLock(foodId);
     } catch(PessimisticLockException | PessimisticLockingFailureException e) {
       log.warn("Pessimistic lock failure on food ID: {}", foodId, e);
-
-      // Decide whether to retry, fallback, or fail
-      throw new IllegalStateException("The food item is currently locked. Please try again later.");
-    } catch (InterruptedException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException("오류 다시 시도해 주시길 바랍니다.");
     }
   }
 }


### PR DESCRIPTION
- 주문 controller, service, repository 를 구현하였습니다.
- dto를 구현하였습니다. 
  - entity를 client와 소통하는 객체로 활용하면 entity나 API의 스펙이 변할 때 마다 불필요한 변화가 각 객체에 강제되기 때문에 따로 dto를 활용하였습니다. 
- 비관적 lock을 사용하여 동시성 문제를 해결하였습니다. 
  - 낙관적 lock도 고려해보았지만 
    - 우선 수량이 무조건적으로 안정적으로 일관성있게 유지되어야 한다는 점
    - 또 retry 로직을 구현한 후 적은 수량에 많은 요청이 몰렸을 때 불필요한 자원의 낭비가 심해질 수 도 있다는 생각에 비관적 lock을 도입하였습니다. 
  - 하지만 추후에 데이터베이스를 분산 (sharding) 한다면 redis의 분산 lock을 장기적으로 고려해볼 수 있다고 생각합니다.  

- 테스트는 Apache Jmeter를 통해 확인하였고 데이터의 일관성도 h2 데이터베이스를 통해서 확인하였습니다. 
  - 내일 local로도 multithreading 환경을 구현하여 테스트를 작성하겠습니다. 