### PR TITLE
feat: Added GlobalExceptionHandler

### DIFF
--- a/src/main/java/com/f_lab/la_planete/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/f_lab/la_planete/controller/GlobalExceptionHandler.java
@@ -1,0 +1,68 @@
+package com.f_lab.la_planete.controller;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.Hidden;
+import jakarta.persistence.PessimisticLockException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.exception.LockTimeoutException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.orm.jpa.JpaSystemException;
+import org.springframework.transaction.TransactionSystemException;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@Hidden
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler(IllegalStateException.class)
+  public ResponseEntity<ErrorResponse> handleIllegalStateException(IllegalStateException e) {
+    return ResponseEntity
+        .status(HttpStatus.CONFLICT)
+        .body(ErrorResponse.of(e.getMessage(), HttpStatus.CONFLICT.value()));
+  }
+
+  /**
+   * 데이터베이스 관련 예외 (e.g. 주로 락을 얻는 대기시간이 오래되어서 요청을 반환할 때)
+   */
+  @ExceptionHandler(JpaSystemException.class)
+  public ResponseEntity<ErrorResponse> handleJpaSystemException(JpaSystemException e) {
+    log.error("JpaSystemException occurred", e);
+    return ResponseEntity
+        .status(HttpStatus.SERVICE_UNAVAILABLE)
+        .body(ErrorResponse.of(
+            "현재 너무 많은 요청을 처리하고 있습니다. 다시 시도해주세요",
+            HttpStatus.SERVICE_UNAVAILABLE.value()));
+  }
+
+  /**
+   * 어플리케이션에서 처리하지 못한 다른 모든 예외
+   */
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponse> handleGenericException(Exception e) {
+    log.error("Unexpected Error occurred. Requires Potential Handling", e);
+    return ResponseEntity
+        .status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .body(ErrorResponse.of(
+            "알 수 없는 오류가 발생했습니다. 다시 시도해주세요",
+            HttpStatus.INTERNAL_SERVER_ERROR.value()));
+  }
+
+  @Getter
+  @AllArgsConstructor
+  static class ErrorResponse {
+    private String message;
+
+    @JsonProperty("status_code")
+    private int statusCode;
+
+    public static ErrorResponse of(String message, int statusCode) {
+      return new ErrorResponse(message, statusCode);
+    }
+  }
+}

--- a/src/main/java/com/f_lab/la_planete/service/OrderService.java
+++ b/src/main/java/com/f_lab/la_planete/service/OrderService.java
@@ -52,12 +52,7 @@ public class OrderService {
   }
 
   private Food findFoodWithLock(Long foodId) {
-    try {
-     return  foodRepository.findFoodByFoodIdWithPessimisticLock(foodId);
-    } catch(PessimisticLockException | PessimisticLockingFailureException e) {
-      log.warn("Pessimistic lock failure on food ID: {}", foodId, e);
-      throw new IllegalStateException("오류 다시 시도해 주시길 바랍니다.");
-    }
+     return foodRepository.findFoodByFoodIdWithPessimisticLock(foodId);
   }
 }
 


### PR DESCRIPTION
- @ControllerAdvice 와 @ExceptionHandler를 추가하여 예외처리 계층을 추가하였습니다. 
- @Hidden을 통해서 `Swagger UI` 가 정상적으로 작동하도록 하였으며 (아닐시에 error 발생)
- 또 기존의 OrderService를 감싸던 try {} block을 지웠습니다. 
- JpaSystemException은 락을 쓰레드가 대기시간으로 인하여 얻는데 실패할 경우 이 예외에 감싸져서 온다는 것을 알았습니다. 
  - 즉 기존의 try {} catch{} 로 감싸 IllegalStateException으로 wrap 하여 처리하려면 그 예외가 던져지는 것과 예외로 따로 TransactionManager에서 JpaSystemException을 던지기 때문에 따로 처리하지 않으면 DispatcherServlet에서 Default로 처리되지 때문에 따로 @ControllerAdvice 에서 @ExceptionHandling을 통해서 관리하게 되었습니다. 

한 thread를 의도적으로 lock을 길게 가지게 했을 때 @ControllerAdvice에서 설계한 대로 예외가 던져지는 것을 Jmeter를 통해 확인하였습니다. 
 

<img width="1163" alt="스크린샷 2024-12-24 오후 7 58 23" src="https://github.com/user-attachments/assets/27f85077-71c8-44f7-a8d1-e498fa1bc58e" />
