### PR TITLE
feat: Added Currency entity

### DIFF
--- a/src/main/java/com/f_lab/la_planete/domain/Currency.java
+++ b/src/main/java/com/f_lab/la_planete/domain/Currency.java
@@ -1,0 +1,43 @@
+package com.f_lab.la_planete.domain;
+
+import com.f_lab.la_planete.domain.base.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.RoundingMode;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "currency")
+public class Currency extends BaseTimeEntity {
+
+  @Id @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private String currencyCode;
+
+  @Column(nullable = false)
+  private String currencySymbol;
+
+  @Column(nullable = false)
+  private int roundingScale;
+
+  @Enumerated(EnumType.STRING)
+  @Column(columnDefinition = "VARCHAR(20) NOT NULL DEFAULT 'FLOOR'")
+  private RoundingMode roundingMode;
+}


### PR DESCRIPTION
화폐에 따라 가격에 사용되는 scale 과 roundmode 가 다를 수 있다는 것을 인지한 후, 이번에는 enum을 활용하기 보다 production code를 변경하지 않아도 되는 데이터베이스를 활용하기로 생각해서 entity를 만들었습니다. 